### PR TITLE
Add output path configuration for Targeted Frame Analysis auto_generated.ini

### DIFF
--- a/backend/analysis/targeted_analysis.py
+++ b/backend/analysis/targeted_analysis.py
@@ -1,9 +1,14 @@
 from pathlib import Path
+from backend.config.Config import Config
 
-
-_filepath      = Path('include', 'auto_generated.ini')
+def get_filepath():
+    config = Config.get_instance()
+    active_game = config.data.active_game
+    filepath_str = config.data.game[active_game].target_analysis_path
+    return Path(filepath_str)
 
 def get_status():
+    _filepath = get_filepath()
     exists = _filepath.exists()
     enabled = False
     if exists:
@@ -12,12 +17,14 @@ def get_status():
     return exists, enabled
 
 def clear(terminal=None):
-    _filepath      .write_text('', encoding='utf-8')
+    _filepath = get_filepath()
+    _filepath.write_text('', encoding='utf-8')
 
     if terminal:
         terminal.print(f'Cleared targeted ini content from <PATH>{_filepath.absolute()}</PATH>')
 
 def generate(export_name, model_hashes, component_names, d3dx_path: Path, terminal, dump_rt = True, force_dump_dds = False, symlink = False, share_dupes = False):
+    _filepath = get_filepath()
     targeted_content = '\n\n'.join([
         '\n'.join([
             '[TextureOverrideModel{}]'.format(i+1),

--- a/backend/config/Config.py
+++ b/backend/config/Config.py
@@ -43,7 +43,7 @@ class Config():
 
     def _create_config(self):
         with open(self._config_filepath, 'w', encoding='utf-8') as f:
-            json.dump(asdict(ConfigData()), f, indent=4)
+            json.dump(asdict(ConfigData()), f, indent=4, ensure_ascii=False)
 
     def _load_config(self) -> dict:
         with open(self._config_filepath, 'r', encoding='utf-8') as f:
@@ -59,7 +59,7 @@ class Config():
 
     def save_config(self):
         with open(self._config_filepath, 'w', encoding='utf-8') as f:
-            json.dump(asdict(self.data), f, indent=4)
+            json.dump(asdict(self.data), f, indent=4, ensure_ascii=False)
 
     def prompt_config_refresh(self):
         ans = ''

--- a/backend/config/structs.py
+++ b/backend/config/structs.py
@@ -25,6 +25,7 @@ class _GameConfigOptionData():
 
 @dataclass
 class _GameConfigData():
+    target_analysis_path      : str = str(Path('.', 'include', 'auto_generated.ini').absolute())
     frame_analysis_parent_path: str = ''
     extract_path              : str = default_extract_path
     game_options     :     _GameConfigOptionData = field(default_factory=lambda:     _GameConfigOptionData())
@@ -50,9 +51,9 @@ class ConfigData():
         }
     )
     def __post_init__(self):
-        for k in self.game:
-            if not is_dataclass(self.game[k]):
-                self.game[k] = _GameConfigData(**self.game[k])
+        for k, v in self.game.items():
+            if not isinstance(v, _GameConfigData):
+                self.game[k] = _GameConfigData(**v)
 
     @staticmethod
     def validate_config_data(d: dict):
@@ -67,7 +68,7 @@ class ConfigData():
         _validate_helper(d, default_config_data, [],       {'active_game', 'targeted_analysis_enabled', 'reverse_shapekeys_hsr', 'reverse_shapekeys_zzz', 'game'})
         _validate_helper(d, default_config_data, ['game'], {'zzz', 'hsr', 'gi', 'hi3'})
         for g in GAME_NAME:
-            _validate_helper(d, default_config_data, ['game', g], {'extract_path', 'frame_analysis_parent_path', 'game_options', 'targeted_options'})
+            _validate_helper(d, default_config_data, ['game', g], {'target_analysis_path', 'extract_path', 'frame_analysis_parent_path', 'game_options', 'targeted_options'})
             _validate_helper(d, default_config_data, ['game', g, 'game_options'], {'clean_extract_folder', 'open_extract_folder', 'delete_frame_analysis'})
             _validate_helper(d, default_config_data, ['game', g, 'targeted_options'], {'force_dump_dds', 'dump_rt', 'symlink', 'share_dupes'})
             

--- a/frontend/extract_form.py
+++ b/frontend/extract_form.py
@@ -73,7 +73,17 @@ class ExtractForm(tk.Frame):
         targeted_dump_frame_title = tk.Label(self.targeted_dump, text='Targeted Frame Analysis', bg='#222', fg='#555', anchor='w', font=('Arial', '16', 'bold'))
         targeted_dump_frame_title.pack(fill='x')
         
-        pp = PathPicker(self.targeted_dump, value=Path('include', 'auto_generated.ini'), callback=None, bg='#333', button_bg=self.accent_color)
+        def handle_target_analysis_path_change(newPath: str):
+            target_analysis_path = str(Path(newPath) / 'auto_generated.ini')
+            self.cfg.data.game[self.variant.value].target_analysis_path = target_analysis_path
+            self.terminal.print('Set Config: /game/{}/target_analysis_path = <PATH>{}</PATH>'.format(self.variant.value, target_analysis_path))
+            from .xtk.PathPicker import get_short_path
+            pp.path = Path(target_analysis_path)
+            pp.path_text = get_short_path(pp.path)
+            pp.path_label.config(text=pp.path_text)
+
+        current_target_analysis_path = self.cfg.data.game[self.variant.value].target_analysis_path
+        pp = PathPicker(self.targeted_dump, value=current_target_analysis_path, callback=handle_target_analysis_path_change, bg='#333', button_bg=self.accent_color)
         pp.pack(side='top', fill='x', pady=(0, 12))
 
         targeted_options = self.cfg.data.game[self.variant.value].targeted_options


### PR DESCRIPTION
### Purpose
This patch adds the ability to specify the output path for the `auto_generated.ini` file when using the Targeted Frame Analysis feature.

### Changes Made
- **GUI Enhancement**: Added a button in the Targeted Frame Analysis GUI to set the output path
- **Configuration**: Added `target_analysis_path` setting to Config.ini, which stores the path per game
- **Unicode Support**: Added `ensure_ascii=False` option when saving Config.ini to properly preserve Unicode characters
### How It Works
1. Click the path button in Targeted Frame Analysis to set the desired output location
2. Press "Generate" to create `auto_generated.ini` directly in the specified path
3. Use "Clear" button to reset the path setting
4. **Benefit**: This eliminates the manual step of moving `auto_generated.ini` from the generation location to the Mods folder
### Additional Resources
I've also created a standalone patch Python file that can be used to overlay on existing versions: 
[patch.py](https://github.com/user-attachments/files/25139841/patch.py)
### Request
I would appreciate it if you could review and consider merging this enhancement into the main repository. This feature streamlines the workflow for users who frequently work with Targeted Frame Analysis.

