### PR TITLE
Change Page class to inherit from str and Enum

### DIFF
--- a/gui_collect/frontend/data.py
+++ b/gui_collect/frontend/data.py
@@ -1,8 +1,8 @@
 # from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 
 
-class Page(StrEnum):
+class Page(str, Enum):
     zzz = "zzz"
     hsr = "hsr"
     gi = "gi"


### PR DESCRIPTION
Downgraded `Page` enum definition in `data.py` to support Python versions < 3.11.
Replaced `StrEnum` inheritance with `(str, Enum)` to resolve `ImportError`.

This fixes #15 and most likely #14
