### PR TITLE
Fix: Add scroll to ID list in Texture Picker and include texture format in hash.json

### DIFF
--- a/gui_collect/backend/analysis/JsonBuilder.py
+++ b/gui_collect/backend/analysis/JsonBuilder.py
@@ -54,9 +54,13 @@ class JsonBuilder:
 
         if component.options["collect_texture_hashes"]:
             if textures:
+                for first_index in textures:
+                    for (texture, texture_type) in textures[first_index]:
+                        texture.async_read_format(blocking=True)
+                        
                 json_component.texture_hashes = [
                     [
-                        [texture_type, texture.path.suffix, texture.hash]
+                        [texture_type, texture.path.suffix, texture.hash, texture._format]
                         for (texture, texture_type) in textures[first_index]
                     ]
                     for first_index in textures

--- a/gui_collect/frontend/texture_grid.py
+++ b/gui_collect/frontend/texture_grid.py
@@ -34,7 +34,7 @@ class TextureGrid(tk.Frame):
 
         self.create_id_picker()
         self.create_header()
-        self.id_picker.grid(row=0, column=0, rowspan=2, padx=(1, 0), sticky="nsew")
+        self.id_picker_container.grid(row=0, column=0, rowspan=2, padx=(1, 0), sticky="nsew")
         self.header.grid(row=0, column=1, sticky="nsew", padx=4, pady=4)
 
         self.multi_mode_enabled = False
@@ -58,8 +58,10 @@ class TextureGrid(tk.Frame):
         self.multi_mode_enabled = False
 
     def create_id_picker(self):
-        self.id_picker = tk.Frame(self, width=74, bg="#333")
-        self.id_picker.pack_propagate(False)
+        self.id_picker_container = tk.Frame(self, width=74, bg="#333")
+        self.id_picker_container.pack_propagate(False)
+        self.id_picker = ScrollableFrame(self.id_picker_container, bg="#333", width=74)
+        self.id_picker.pack(fill="both", expand=True)
 
     def create_header(self):
         self.header = tk.Frame(self, bg="#111")
@@ -259,10 +261,10 @@ class TextureGrid(tk.Frame):
         return filter_mask
 
     def refresh_id_picker(self, component_index: int, first_index: int):
-        for child in self.id_picker.winfo_children():
+        for child in self.id_picker.interior.winfo_children():
             child.destroy()
 
-        header = tk.Label(self.id_picker, text="ID", font=("Arial", "24", "bold"))
+        header = tk.Label(self.id_picker.interior, text="ID", font=("Arial", "24", "bold"))
         header.config(bg="#333", fg="#e8eaed")
         header.pack(side="top", pady="4", anchor="center")
 
@@ -272,7 +274,7 @@ class TextureGrid(tk.Frame):
             active_id = self.frames[component_index][first_index]["active_id"]
 
             id_label = tk.Label(
-                self.id_picker,
+                self.id_picker.interior,
                 text=str(id),
                 cursor="hand2",
                 font=("Arial", "10", "bold"),

--- a/gui_collect/frontend/xtk/ScrollableFrame.py
+++ b/gui_collect/frontend/xtk/ScrollableFrame.py
@@ -108,7 +108,7 @@ class ScrollableFrame(tk.Frame):
         """
         Can handle windows or linux
         """
-        speed = 1 / 6
+        speed = 1 / 30
         if platform == "linux" or platform == "linux2":
             fraction = self._scrollbar.get()[0] + scroll * speed
         else:


### PR DESCRIPTION
> **Note:** The code changes and descriptions in this PR were generated with the assistance of an AI (Gemini). Please excuse any minor imperfections.

### Changes
1. **Fixed ID List Overflow in Texture Picker**
   - **Issue:** When a large number of IDs were loaded in the Texture Picker screen, the list overflowed and was cut off outside the window.
   - **Fix:** Wrapped the `id_picker` component in `texture_grid.py` with a `ScrollableFrame`, allowing users to scroll through all IDs without layout issues.
2. **Added Texture Storage Format to `hash.json` Export** (Resolves [#22](https://github.com/Petrascyll/gui_collect/issues/22))
   - **Motivation:** There are frequent cases where knowing the exact storage format of a texture (e.g., `BC7_UNORM`) is necessary after extraction. 
   - **Fix:** Modified `JsonBuilder.py` to asynchronously read the texture format (`texture._format`) and append it as the 4th element in the JSON array during export, so this information is now conveniently saved alongside the rest of the data.
3. **Fine-Tuned Scroll Sensitivity**
   - **Issue:** The scrolling behavior in `ScrollableFrame` felt too abrupt and chunky, making it slightly uncomfortable to navigate.
   - **Fix:** Decreased the mouse wheel scroll speed multiplier from `1 / 6` to `1 / 30` in `ScrollableFrame.py`, resulting in a much smoother and more granular scrolling experience.

### Modified Files
- `gui_collect/frontend/texture_grid.py`
- `gui_collect/backend/analysis/JsonBuilder.py`
- `gui_collect/frontend/xtk/ScrollableFrame.py`